### PR TITLE
Fix for empty games list (Player::GetOwnedGames)

### DIFF
--- a/src/Syntax/SteamApi/Steam/Player.php
+++ b/src/Syntax/SteamApi/Steam/Player.php
@@ -90,7 +90,7 @@ class Player extends Client {
         $client = $this->getServiceResponse($arguments);
 
         // Clean up the games
-        $games = $this->convertToObjects($client->games);
+        $games = $this->convertToObjects(isset($client->games) ? $client->games : array());
 
         return $games;
     }


### PR DESCRIPTION
In case a player has no games, "games" key is not present and Exception is thrown.