### PR TITLE
Fix for profilestate field

### DIFF
--- a/src/Syntax/SteamApi/Containers/Player.php
+++ b/src/Syntax/SteamApi/Containers/Player.php
@@ -51,7 +51,7 @@ class Player extends BaseContainer {
 		$this->steamId                  = $player->steamid;
 		$this->steamIds                 = (new Id((int)$this->steamId));
 		$this->communityVisibilityState = $player->communityvisibilitystate;
-		$this->profileState             = $player->profilestate;
+		$this->profileState             = $this->checkIssetField($player, 'profilestate');
 		$this->personaName              = $player->personaname;
 		$this->lastLogoff               = date('F jS, Y h:ia', $player->lastlogoff);
 		$this->profileUrl               = $player->profileurl;


### PR DESCRIPTION
profilestate field is not always present, so, exception is thrown when trying to get this property if it is absent.