### PR TITLE
fixed percentThroughLevel to return the correct value

### DIFF
--- a/src/Syntax/SteamApi/Containers/Player/Level.php
+++ b/src/Syntax/SteamApi/Containers/Player/Level.php
@@ -25,22 +25,8 @@ class Level {
 		$this->currentLevelFloor    = $this->xpForCurrentLevel;
 		$this->currentLevelCeiling = $this->playerXp + $this->xpToLevelUp;
 
-		$levelRange = $this->currentLevelCeiling - $this->currentLevelFloor;
-
-		$this->percentThroughLevel = $this->percent($this->xpToLevelUp, $levelRange);
-	}
-
-	private function percent ($num_amount, $num_total)
-	{
-		if($num_amount == 0 || $num_total == 0){
-			return 0;
-		}
-		else {
-			$count1 = $num_amount / $num_total;
-			$count2 = $count1 * 100;
-			$count = number_format($count2, 0);
-			return $count;
-		}
+		// arbitrary range formula. n = value in the middle ( n - min ) / ( max - min ) * 100
+		$this->percentThroughLevel = ( $this->playerXp - $this->currentLevelFloor ) / ( $this->currentLevelCeiling - $this->currentLevelFloor ) * 100;		
 	}
 
 }


### PR DESCRIPTION
Using the percent function was returning the wrong value for $this->percentThroughLevel. As an example, on my Steam profile I had a LevelFloor of 600 and a LevelCeiling of 700. My current playerXp is 656, so with a 100 point difference, 656xp should be 56% progress completed. 

With the above values mentioned it was returning 36 which would make the progress bar less than it really should be on the front end. 

The correct formula for an arbitrary range is ( n - min ) / ( max - min ) * 100 while n = playerXp or whatever the current value is in between the range.

Please review and let me know any concerns.

Thanks for your hard work on this package. :)
