### PR TITLE
Add isset check on the lastlogoff property

### DIFF
--- a/src/Syntax/SteamApi/Containers/Player.php
+++ b/src/Syntax/SteamApi/Containers/Player.php
@@ -58,7 +58,7 @@ class Player extends BaseContainer
         $this->communityVisibilityState = $player->communityvisibilitystate;
         $this->profileState             = $this->checkIssetField($player, 'profilestate');
         $this->personaName              = $player->personaname;
-        $this->lastLogoff               = date('F jS, Y h:ia', $player->lastlogoff);
+        $this->lastLogoff               = date('F jS, Y h:ia', $this->checkIssetField($player, 'lastlogoff'));
         $this->profileUrl               = $player->profileurl;
         $this->avatar                   = $this->getImageForAvatar($player->avatar);
         $this->avatarMedium             = $this->getImageForAvatar($player->avatarmedium);


### PR DESCRIPTION
I've found that the lastlogoff property is missing if the account you're fetching information for is very new and hasn't been setup with a community profile. This change checks for the property using the built-in isset check. The value will fall back to the current server date/time if the property is missing from the api response.