### PR TITLE
Adds new $playtimeTwoWeeksReadable value for Games and Items

### DIFF
--- a/examples/player/GetOwnedGames.txt
+++ b/examples/player/GetOwnedGames.txt
@@ -6,7 +6,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 251570
                     [name] => 7 Days to Die
-                    [playtimeTwoWeeks] => 0 minutes
+                    [playtimeTwoWeeks] => 0
+                    [playtimeTwoWeeksReadable] => 0 minutes
                     [playtimeForever] => 12
                     [playtimeForeverReadable] => 12 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/251570/c8f826b116770525b68e7b4e37ad83ca044ae760.jpg
@@ -19,7 +20,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 22650
                     [name] => Alien Breed 2: Assault
-                    [playtimeTwoWeeks] => 0 minutes
+                    [playtimeTwoWeeks] => 0
+                    [playtimeTwoWeeksReadable] => 0 minutes
                     [playtimeForever] => 0
                     [playtimeForeverReadable] => 0 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/22650/a10e00aa5fc77cc14deb38f7da48e5da40b18503.jpg
@@ -32,7 +34,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 22670
                     [name] => Alien Breed 3: Descent
-                    [playtimeTwoWeeks] => 0 minutes
+                    [playtimeTwoWeeks] => 0
+                    [playtimeTwoWeeksReadable] => 0 minutes
                     [playtimeForever] => 0
                     [playtimeForeverReadable] => 0 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/22670/276d9c54a181c2baf809c53c6172a5475866e693.jpg
@@ -45,7 +48,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 22610
                     [name] => Alien Breed: Impact
-                    [playtimeTwoWeeks] => 0 minutes
+                    [playtimeTwoWeeks] => 0
+                    [playtimeTwoWeeksReadable] => 0 minutes
                     [playtimeForever] => 0
                     [playtimeForeverReadable] => 0 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/22610/963d4d2b346f7258940a9bb9c8a5e319ec1bc781.jpg

--- a/examples/player/GetRecentlyPlayedGames.txt
+++ b/examples/player/GetRecentlyPlayedGames.txt
@@ -6,7 +6,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 214490
                     [name] => Alien: Isolation
-                    [playtimeTwoWeeks] => 1 hours 13 minutes
+                    [playtimeTwoWeeks] => 73
+                    [playtimeTwoWeeksReadable] => 1 hours 13 minutes
                     [playtimeForever] => 73
                     [playtimeForeverReadable] => 1 hours 13 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/214490/7bf964858835da75630a43ac0ddbf0f66a40902f.jpg
@@ -19,7 +20,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 258970
                     [name] => Gauntletâ„¢
-                    [playtimeTwoWeeks] => 2 hours 28 minutes
+                    [playtimeTwoWeeks] => 148
+                    [playtimeTwoWeeksReadable] => 2 hours 28 minutes
                     [playtimeForever] => 148
                     [playtimeForeverReadable] => 2 hours 28 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/258970/76e95a57a669c30984c9dcd32879536746d75de9.jpg
@@ -32,7 +34,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 249130
                     [name] => LEGO MARVEL Super Heroes
-                    [playtimeTwoWeeks] => 46 minutes
+                    [playtimeTwoWeeks] => 46
+                    [playtimeTwoWeeksReadable] => 46 minutes
                     [playtimeForever] => 46
                     [playtimeForeverReadable] => 46 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/249130/8462ed9e1004624c7109233eafd7098211da9f86.jpg
@@ -45,7 +48,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 241930
                     [name] => Middle-earth: Shadow of Mordor
-                    [playtimeTwoWeeks] => 1 hours 21 minutes
+                    [playtimeTwoWeeks] => 71
+                    [playtimeTwoWeeksReadable] => 1 hours 21 minutes
                     [playtimeForever] => 81
                     [playtimeForeverReadable] => 1 hours 21 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/241930/161afab3c9f725f593635723cc64a7fbeb324ead.jpg
@@ -58,7 +62,8 @@ Syntax\SteamApi\Collection Object
                 (
                     [appId] => 221680
                     [name] => Rocksmith 2014
-                    [playtimeTwoWeeks] => 2 hours 30 minutes
+                    [playtimeTwoWeeks] => 150
+                    [playtimeTwoWeeksReadable] => 2 hours 30 minutes
                     [playtimeForever] => 753
                     [playtimeForeverReadable] => 12 hours 33 minutes
                     [icon] => http://media.steampowered.com/steamcommunity/public/images/apps/221680/26c3d3ad45c9386e909613e5d115e73955501844.jpg

--- a/src/Syntax/SteamApi/Containers/Game.php
+++ b/src/Syntax/SteamApi/Containers/Game.php
@@ -10,6 +10,8 @@ class Game extends BaseContainer
 
     public $playtimeTwoWeeks;
 
+    public $playtimeTwoWeeksReadable;
+
     public $playtimeForever;
 
     public $playtimeForeverReadable;
@@ -26,7 +28,8 @@ class Game extends BaseContainer
     {
         $this->appId                    = $app->appid;
         $this->name                     = $this->checkIssetField($app, 'name');
-        $this->playtimeTwoWeeks         = isset($app->playtime_2weeks) ? $this->convertFromMinutes($app->playtime_2weeks) : '0 minutes';
+        $this->playtimeTwoWeeks         = $this->checkIssetField($app, 'playtime_2weeks', 0);
+        $this->playtimeTwoWeeksReadable = $this->convertFromMinutes($this->playtimeTwoWeeks);
         $this->playtimeForever          = $this->checkIssetField($app, 'playtime_forever', 0);
         $this->playtimeForeverReadable  = $this->convertFromMinutes($this->playtimeForever);
         $this->icon                     = $this->checkIssetImage($app, 'img_icon_url');

--- a/src/Syntax/SteamApi/Containers/Item.php
+++ b/src/Syntax/SteamApi/Containers/Item.php
@@ -10,6 +10,8 @@ class Item extends BaseContainer
 
     public $playtimeTwoWeeks;
 
+    public $playtimeTwoWeeksReadable;
+
     public $playtimeForever;
 
     public $playtimeForeverReadable;
@@ -26,7 +28,8 @@ class Item extends BaseContainer
     {
         $this->appId                    = $app->appid;
         $this->name                     = $this->checkIssetField($app, 'name');
-        $this->playtimeTwoWeeks         = isset($app->playtime_2weeks) ? $this->convertFromMinutes($app->playtime_2weeks) : '0 minutes';
+        $this->playtimeTwoWeeks         = $this->checkIssetField($app, 'playtime_2weeks', 0);
+        $this->playtimeTwoWeeksReadable = $this->convertFromMinutes($this->playtimeTwoWeeks);
         $this->playtimeForever          = $this->checkIssetField($app, 'playtime_forever', 0);
         $this->playtimeForeverReadable  = $this->convertFromMinutes($this->playtimeForever);
         $this->icon                     = $this->checkIssetImage($app, 'img_icon_url');

--- a/tests/PlayerTest.php
+++ b/tests/PlayerTest.php
@@ -57,7 +57,7 @@ class PlayerTest extends BaseTester {
         $this->assertInstanceOf('Syntax\SteamApi\Containers\Game', $games->first());
 
         $attributes = [
-            'appId', 'name', 'playtimeTwoWeeks', 'playtimeForever', 'playtimeForeverReadable',
+            'appId', 'name', 'playtimeTwoWeeks', 'playtimeTwoWeeksReadable', 'playtimeForever', 'playtimeForeverReadable',
             'icon', 'logo', 'header', 'hasCommunityVisibleStats'
         ];
         $this->assertObjectHasAttributes($attributes, $games->first());
@@ -72,7 +72,7 @@ class PlayerTest extends BaseTester {
         $this->assertInstanceOf('Syntax\SteamApi\Containers\Game', $games->first());
 
         $attributes = [
-            'appId', 'name', 'playtimeTwoWeeks', 'playtimeForever', 'playtimeForeverReadable',
+            'appId', 'name', 'playtimeTwoWeeks', 'playtimeTwoWeeksReadable', 'playtimeForever', 'playtimeForeverReadable',
             'icon', 'logo', 'header', 'hasCommunityVisibleStats'
         ];
         $this->assertObjectHasAttributes($attributes, $games->first());
@@ -92,7 +92,7 @@ class PlayerTest extends BaseTester {
         $this->assertEquals(1, $games->count());
 
         $attributes = [
-            'appId', 'name', 'playtimeTwoWeeks', 'playtimeForever', 'playtimeForeverReadable',
+            'appId', 'name', 'playtimeTwoWeeks', 'playtimeTwoWeeksReadable', 'playtimeForever', 'playtimeForeverReadable',
             'icon', 'logo', 'header', 'hasCommunityVisibleStats'
         ];
         $this->assertObjectHasAttributes($attributes, $games->first());
@@ -107,7 +107,7 @@ class PlayerTest extends BaseTester {
         $this->assertInstanceOf('Syntax\SteamApi\Containers\Game', $games->first());
 
         $attributes = [
-            'appId', 'name', 'playtimeTwoWeeks', 'playtimeForever', 'playtimeForeverReadable',
+            'appId', 'name', 'playtimeTwoWeeks', 'playtimeTwoWeeksReadable', 'playtimeForever', 'playtimeForeverReadable',
             'icon', 'logo', 'header', 'hasCommunityVisibleStats'
         ];
         $this->assertObjectHasAttributes($attributes, $games->first());
@@ -123,7 +123,7 @@ class PlayerTest extends BaseTester {
         $this->assertEquals(1, $games->count());
 
         $attributes = [
-            'appId', 'name', 'playtimeTwoWeeks', 'playtimeForever', 'playtimeForeverReadable',
+            'appId', 'name', 'playtimeTwoWeeks', 'playtimeTwoWeeksReadable', 'playtimeForever', 'playtimeForeverReadable',
             'icon', 'logo', 'header', 'hasCommunityVisibleStats'
         ];
         $this->assertObjectHasAttributes($attributes, $games->first());


### PR DESCRIPTION
$playtimeTwoWeeks now holds the raw minutes, $playtimeTwoWeeksReadable holds the human readable value like `2 hours 34 minutes`.
Also updates corresponding tests.

Fix for #44 