### PR TITLE
Adds fix for app name inside GetPlayerAchievements()

### DIFF
--- a/src/Syntax/SteamApi/Steam/User/Stats.php
+++ b/src/Syntax/SteamApi/Steam/User/Stats.php
@@ -83,9 +83,12 @@ class Stats extends Client
             // In these cases, try again with the name.
             if (is_int($appId)) {
                 $app     = $this->app()->appDetails($appId);
-                $appName = str_replace(' ', '', $app->first()->name);
 
-                return $this->GetPlayerAchievements($appName);
+                if (isset($app->first()->name)) {
+                    $appName = str_replace(' ', '', $app->first()->name);
+
+                    return $this->GetPlayerAchievements($appName);
+                }
             }
 
             // If the name and ID fail, return null.


### PR DESCRIPTION
Referenced function: `GetPlayerAchievements()`

`$appName = str_replace(' ', '', $app->first()->name);` caused several "Trying to get property of non-object" exceptions while running the function for hundreds of games. I didn't investigated why `$app`was empty but it was so this is just a small hotfix.

The exceptions can be reproduced with the Steam App ID `219540` (Arma 2: Operation Arrowhead Beta (Obsolete)).
