### PR TITLE
Use plural of days, hours and minutes only for values > 1

### DIFF
--- a/src/Syntax/SteamApi/Containers/Game.php
+++ b/src/Syntax/SteamApi/Containers/Game.php
@@ -82,13 +82,14 @@ class Game extends BaseContainer
         $output = '';
 
         if ($days > 0) {
-            $output .= $days . ' days ';
-        }
-        if ($hours > 0) {
-            $output .= $hours . ' hours ';
+            $output .= $days . ($days > 1 ? ' days ' : ' day ');
         }
 
-        $output .= $minutes . ' minutes';
+        if ($hours > 0) {
+            $output .= $hours . ($hours > 1 ? ' hours ' : ' hour ');
+        }
+
+        $output .= $minutes . ($minutes > 1 ? ' minutes' : ' minute');
 
         return $output;
     }

--- a/src/Syntax/SteamApi/Containers/Item.php
+++ b/src/Syntax/SteamApi/Containers/Item.php
@@ -82,13 +82,14 @@ class Item extends BaseContainer
         $output = '';
 
         if ($days > 0) {
-            $output .= $days . ' days ';
-        }
-        if ($hours > 0) {
-            $output .= $hours . ' hours ';
+            $output .= $days . ($days > 1 ? ' days ' : ' day ');
         }
 
-        $output .= $minutes . ' minutes';
+        if ($hours > 0) {
+            $output .= $hours . ($hours > 1 ? ' hours ' : ' hour ');
+        }
+
+        $output .= $minutes . ($minutes > 1 ? ' minutes' : ' minute');
 
         return $output;
     }


### PR DESCRIPTION
Updates the `convertFromMinutes()` functions inside Game and Item classes to use the plural version of days, hours and minutes only if the value is > 1