### PR TITLE
[L 5.4] Address an 'alias' error

### DIFF
--- a/src/Syntax/SteamApi/SteamApiServiceProvider.php
+++ b/src/Syntax/SteamApi/SteamApiServiceProvider.php
@@ -32,9 +32,9 @@ class SteamApiServiceProvider extends ServiceProvider
     public function register()
     {
         $this->registerAlias();
-
-        $this->app['steam-api'] = $this->app->share(function () {
-            return new Client;
+        
+        $this->app->bind('steam-api', function ($app) {
+        	return new Client;
         });
     }
 


### PR DESCRIPTION
Fix for the "Call to undefined method Illuminate\Foundation\Application::share()" error introduced in 5.4

```[2017-01-25 09:34:00] local.CRITICAL: Symfony\Component\Debug\Exception\FatalThrowableError: Call to undefined method Illuminate\Foundation\Application::share() in XXX\vendor\syntax\steam-api\src\Syntax\SteamApi\SteamApiServiceProvider.php:36
Stack trace:
#0 XXX\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(568): Syntax\SteamApi\SteamApiServiceProvider->register()
#1 XXX\vendor\laravel\framework\src\Illuminate\Foundation\ProviderRepository.php(74): Illuminate\Foundation\Application->register(Object(Syntax\SteamApi\SteamApiServiceProvider))
#2 XXX\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(543): Illuminate\Foundation\ProviderRepository->load(Array)
#3 XXX\vendor\laravel\framework\src\Illuminate\Foundation\Bootstrap\RegisterProviders.php(17): Illuminate\Foundation\Application->registerConfiguredProviders()
#4 XXX\vendor\laravel\framework\src\Illuminate\Foundation\Application.php(208): Illuminate\Foundation\Bootstrap\RegisterProviders->bootstrap(Object(Illuminate\Foundation\Application))
#5 XXX\vendor\laravel\framework\src\Illuminate\Foundation\Console\Kernel.php(270): Illuminate\Foundation\Application->bootstrapWith(Array)
#6 XXX\vendor\laravel\framework\src\Illuminate\Foundation\Console\Kernel.php(115): Illuminate\Foundation\Console\Kernel->bootstrap()
#7 XXX\artisan(35): Illuminate\Foundation\Console\Kernel->handle(Object(Symfony\Component\Console\Input\ArgvInput), Object(Symfony\Component\Console\Output\ConsoleOutput))
#8 {main} {"identification":{"id":"3169e9b0-b1cb-45c0-ab0a-334b6556921d"}} 
```