### PR TITLE
Upgrade for Laravel 5.4

### DIFF
--- a/src/Syntax/SteamApi/SteamApiServiceProvider.php
+++ b/src/Syntax/SteamApi/SteamApiServiceProvider.php
@@ -33,7 +33,7 @@ class SteamApiServiceProvider extends ServiceProvider
     {
         $this->registerAlias();
 
-        $this->app['steam-api'] = $this->app->share(function () {
+        $this->app->singleton('steam-api', function () {
             return new Client;
         });
     }


### PR DESCRIPTION
Switched from Application#share to Application#singleton to make the Steam-API Laravel 5.4 ready. See https://laravel.com/docs/5.4/upgrade