### PR TITLE
Fixed issue with parsing User ID as integer

### DIFF
--- a/src/Syntax/SteamApi/Containers/Group.php
+++ b/src/Syntax/SteamApi/Containers/Group.php
@@ -32,7 +32,7 @@ class Group
         $this->members = new Collection;
 
         foreach ($group->members->steamID64 as $member) {
-            $this->members->add((new Client)->convertId((int)(string)$member));
+            $this->members->add((new Client)->convertId((string)$member));
         }
     }
 }


### PR DESCRIPTION
Parsing XML member id to integer resulted in incorrect value. Removed
integer parsing as wasn't actually required anywhere.