### PR TITLE
Fix 'readable' playtime lacking spaces

### DIFF
--- a/src/Syntax/SteamApi/Containers/BaseContainer.php
+++ b/src/Syntax/SteamApi/Containers/BaseContainer.php
@@ -63,8 +63,8 @@ abstract class BaseContainer
      */
     protected function pluralize($word, $count)
     {
-        if ($count === 1) {
-            return $word;
+        if ((int) $count === 1) {
+            return $word .' ';
         }
 
         return $word .'s ';

--- a/src/Syntax/SteamApi/Containers/BaseContainer.php
+++ b/src/Syntax/SteamApi/Containers/BaseContainer.php
@@ -67,7 +67,7 @@ abstract class BaseContainer
             return $word;
         }
 
-        return $word .'s';
+        return $word .'s ';
     }
 
     /**


### PR DESCRIPTION
The value returned using `readable` (e.g. `$player->playtimeForeverReadable`) lacks spaces between each value, so a value that would typically say `176 days 4 hours 32 minutes` actually says `176 days4 hours32 minutes`.