### PR TITLE
Language attribute for client requests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: php
 
 php:
+  - 7.2
+  - 7.1
   - 7.0
-  - 5.6
-  - 5.5
 
 notifications:
   slack: nukacode:HyFrc2QLi5PC5fPxadm07O5v

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Each service from the steam api has it's own methods you can use.
 - [User](#user)
 - [User Stats](#user-stats)
 - [App](#app)
+- [Package](#package)
 - [Group](#group)
 
 ### Global
@@ -304,13 +305,15 @@ Steam::app()
 ```
 
 #### appDetails
-This gets all the details for a game.  This is most of the infomation from the store page of a game.
+This gets all the details for a game.  This is most of the information from the store page of a game.
 
 ##### Arguments
 
 Name | Type | Description | Required | Default
 -----|------|-------------|----------|---------
 appIds| int[] | The ids of the games you want details for | Yes |
+cc | string | The cc is the country code, you can get appropriate currency values according to [ISO 3166-1](https://wikipedia.org/wiki/ISO_3166-1) | No |
+l | string | The l is the language parameter, you can get the appropriate language according to [ISO 639-1](https://wikipedia.org/wiki/ISO_639-1) (If there is one) | No |
 
 
 > Example Output: [appDetails](./examples/app/appDetails.txt)
@@ -319,6 +322,27 @@ appIds| int[] | The ids of the games you want details for | Yes |
 This method will return an array of app objects directly from steam.  It includes the appId and the app name.
 
 > Example Output: [GetAppList](./examples/app/GetAppList.txt)
+
+### Package
+This method will get details for packages.
+
+```php
+Steam::package()
+```
+
+#### packageDetails
+This gets all the details for a package. This is most of the information from the store page of a package.
+
+##### Arguments
+
+Name | Type | Description | Required | Default
+-----|------|-------------|----------|---------
+packIds| int[] | The ids of the packages you want details for | Yes |
+cc | string | The cc is the country code, you can get appropriate currency values according to [ISO 3166-1](https://wikipedia.org/wiki/ISO_3166-1) | No |
+l | string | The l is the language parameter, you can get the appropriate language according to [ISO 639-1](https://wikipedia.org/wiki/ISO_639-1) (If there is one) | No |
+
+
+> Example Output: [packageDetails](./examples/package/packageDetails.txt)
 
 ### Group
 This service is used to get details on a steam group.

--- a/examples/package/packageDetails.txt
+++ b/examples/package/packageDetails.txt
@@ -1,0 +1,47 @@
+Array
+(
+    [0] => stdClass Object
+        (
+            [id] => 76710
+            [name] => Just Cause 3 XL
+            [page_image] => https: //steamcdn-a.akamaihd.net/steam/subs/76710/header.jpg?t=1449600260
+            [header] => https: //steamcdn-a.akamaihd.net/steam/subs/76710/header_ratio.jpg?t=1449600260
+            [small_logo] => https: //steamcdn-a.akamaihd.net/steam/subs/76710/capsule_231x87.jpg?t=1449600260
+            [apps] => Array(
+                [0] => stdClass Object(
+                    [id] => 225540
+                    [name] => Just Cause™ 3
+                )
+
+                [1] => stdClass Object(
+                    [id] => 401850
+                    [name] => Just Cause™ 3 DLC: Air, Land & Sea Expansion Pass
+                )
+
+            )
+
+            [page_content] => none[price] => stdClass Object(
+                [currency] => USD
+                [initial] => 4499
+                [final] => 4499
+                [discount_percent] => 0
+                [individual] => 4498
+            )
+
+            [platforms] => stdClass Object(
+                [windows] => 1
+                [mac] => 
+                [linux] =>
+            )
+
+            [release] => stdClass Object(
+                [coming_soon] => 
+                [date] =>
+            )
+
+            [controller] => stdClass Object(
+                [full_gamepad] => 1
+            )
+
+        )
+)

--- a/src/Syntax/SteamApi/Client.php
+++ b/src/Syntax/SteamApi/Client.php
@@ -17,6 +17,7 @@ use Syntax\SteamApi\Exceptions\ClassNotFoundException;
  * @method \Syntax\SteamApi\Steam\User       user($steamId)
  * @method \Syntax\SteamApi\Steam\User\Stats userStats($steamId)
  * @method \Syntax\SteamApi\Steam\App        app()
+ * @method \Syntax\Steamapi\Steam\Package    package()
  * @method \Syntax\SteamApi\Steam\Group      group()
  * @method \Syntax\SteamApi\Steam\Item       item($appId)
  */

--- a/src/Syntax/SteamApi/Client.php
+++ b/src/Syntax/SteamApi/Client.php
@@ -107,7 +107,6 @@ class Client
         $parameters = [
             'key'    => $this->apiKey,
             'format' => $this->apiFormat,
-            'l' => \Config::get('steam-api.steamLang')
         ];
 
         if (! empty($arguments)) {

--- a/src/Syntax/SteamApi/Client.php
+++ b/src/Syntax/SteamApi/Client.php
@@ -107,6 +107,7 @@ class Client
         $parameters = [
             'key'    => $this->apiKey,
             'format' => $this->apiFormat,
+            'l' => \Config::get('steam-api.steamLang')
         ];
 
         if (! empty($arguments)) {

--- a/src/Syntax/SteamApi/Containers/Package.php
+++ b/src/Syntax/SteamApi/Containers/Package.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Syntax\SteamApi\Containers;
+
+class Package extends BaseContainer
+{
+    public $id;
+    public $name;
+    public $page_image;
+    public $header;
+    public $small_logo;
+    public $apps;
+    public $page_content;
+    public $price;
+    public $platforms;
+    public $release;
+
+    public function __construct($package, $id)
+    {
+        $this->id = (int) $id;
+        $this->name = $package->name;
+        $this->apps = $package->apps;
+        $this->page_content = $this->checkIssetField($package, 'page_content', 'none');
+        $this->header = $this->checkIssetField($package, 'header_image', 'none');
+        $this->small_logo = $this->checkIssetField($package, 'small_logo', 'none');
+        $this->page_image = $this->checkIssetField($package, 'page_image', 'none');
+        $this->price = $this->formatPriceObject($package, 'price');
+        $this->platforms = $package->platforms;
+        $this->controller = $package->controller;
+        $this->release = $package->release_date;
+    }
+}

--- a/src/Syntax/SteamApi/Steam/App.php
+++ b/src/Syntax/SteamApi/Steam/App.php
@@ -15,7 +15,7 @@ class App extends Client
         $this->interface = 'api';
     }
 
-    public function appDetails($appIds, $language = 'english')
+    public function appDetails($appIds, $country = null, $language = null)
     {
         // Set up the api details
         $this->method  = 'appdetails';
@@ -24,6 +24,7 @@ class App extends Client
         // Set up the arguments
         $arguments = [
             'appids' => $appIds,
+            'cc' => $country,
             'l' => $language,
         ];
 

--- a/src/Syntax/SteamApi/Steam/App.php
+++ b/src/Syntax/SteamApi/Steam/App.php
@@ -15,7 +15,7 @@ class App extends Client
         $this->interface = 'api';
     }
 
-    public function appDetails($appIds)
+    public function appDetails($appIds, $language = 'english')
     {
         // Set up the api details
         $this->method  = 'appdetails';
@@ -24,6 +24,7 @@ class App extends Client
         // Set up the arguments
         $arguments = [
             'appids' => $appIds,
+            'l' => $language,
         ];
 
         // Get the client

--- a/src/Syntax/SteamApi/Steam/Package.php
+++ b/src/Syntax/SteamApi/Steam/Package.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Syntax\SteamApi\Steam;
+
+use Syntax\SteamApi\Client;
+use NukaCode\Database\Collection;
+use Syntax\SteamApi\Containers\Package as PackageContainer;
+
+class Package extends Client
+{
+    public function __construct()
+    {
+        parent::__construct();
+        $this->url = 'http://store.steampowered.com/';
+        $this->interface = 'api';
+    }
+
+    public function packageDetails($packIds, $cc = null, $language = null)
+    {
+        // Set up the api details
+        $this->method = 'packagedetails';
+        $this->version = null;
+        // Set up the arguments
+        $arguments = [
+            'packageids' => $packIds,
+            'cc'         => $cc,
+            'l'          => $language,
+        ];
+        // Get the client
+        $client = $this->setUpClient($arguments);
+        $packs = $this->convertToObjects($client, $packIds);
+
+        return $packs;
+    }
+
+    protected function convertToObjects($package, $packIds)
+    {
+        $convertedPacks = $this->convertPacks($package, $packIds);
+        $package = $this->sortObjects($convertedPacks);
+
+        return $package;
+    }
+
+    /**
+     * @param $packs
+     *
+     * @return Collection
+     */
+    protected function convertPacks($packages, $packIds)
+    {
+        $convertedPacks = new Collection();
+        foreach ($packages as $package) {
+            if (isset($package->data)) {
+                $convertedPacks->add(new PackageContainer($package->data, $packIds));
+            }
+        }
+
+        return $convertedPacks;
+    }
+}

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -7,11 +7,5 @@ return array(
 	 * Once you get your key, add it here.
 	*/
 	'steamApiKey' => env('STEAM_API_KEY'),
-	
-	/**
-	 * Localized language paramter
-	 * Steam will default back to English if the requested language is not available
-	*/
-	'steamLang' => env('STEAM_LANG', 'english'),
 
 );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -7,4 +7,5 @@ return array(
 	 * Once you get your key, add it here.
 	*/
 	'steamApiKey' => env('STEAM_API_KEY'),
+	'steamLang' => env('STEAM_LANG', 'english'),
 );

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -7,5 +7,11 @@ return array(
 	 * Once you get your key, add it here.
 	*/
 	'steamApiKey' => env('STEAM_API_KEY'),
+	
+	/**
+	 * Localized language paramter
+	 * Steam will default back to English if the requested language is not available
+	*/
 	'steamLang' => env('STEAM_LANG', 'english'),
+
 );

--- a/tests/BaseTester.php
+++ b/tests/BaseTester.php
@@ -15,6 +15,8 @@ class BaseTester extends TestCase {
 
     protected $appId     = 620;
 
+    protected $packageId = 76710;
+
     protected $groupId   = 103582791429521412;
 
     protected $groupName = 'Valve';
@@ -87,6 +89,11 @@ class BaseTester extends TestCase {
         $this->checkNestedAppProperties($app);
     }
 
+    protected function checkPackageProperties($package)
+    {
+        $this->checkNestedPackageProperties($package);
+    }
+
     protected function checkGroupProperties($group)
     {
         $this->checkGroupMainSummaryProperties($group);
@@ -132,6 +139,18 @@ class BaseTester extends TestCase {
 
         $attributes = ['score', 'url'];
         $this->assertObjectHasAttributes($attributes, $app->metacritic);
+    }
+
+    /**
+     * @param $packahe
+     */
+    private function checkNestedPackageProperties($packahe)
+    {
+        $attributes = ['currency', 'initial', 'final', 'discount_percent', 'individual'];
+        $this->assertObjectHasAttributes($attributes, $packahe->price);
+
+        $attributes = ['windows', 'mac', 'linux'];
+        $this->assertObjectHasAttributes($attributes, $packahe->platforms);
     }
 
     /**

--- a/tests/PackageTest.php
+++ b/tests/PackageTest.php
@@ -1,0 +1,28 @@
+<?php
+
+require_once 'BaseTester.php';
+
+/** @group Package */
+class PackageTest extends BaseTester
+{
+    /** @test */
+    public function it_gets_details_for_an_package_by_id()
+    {
+        $details = $this->steamClient->package()->packageDetails($this->packageId);
+
+        $this->assertCount(1, $details);
+
+        $detail = $details->first();
+
+        $this->checkPackageProperties($detail);
+        $this->checkPackageClasses($detail);
+    }
+
+    /**
+     * @param $detail
+     */
+    private function checkPackageClasses($detail)
+    {
+        $this->assertInstanceOf('Syntax\SteamApi\Containers\Package', $detail);
+    }
+}


### PR DESCRIPTION
This pull request adds the possibility to define a language for Client requests. This is especially useful when fetching game data (e.g. descriptions).

Steam provides these in the requested language (e.g. German) if possible. Otherwise the API defaults to English.

Example via a normal web call:

```
https://store.steampowered.com/api/appdetails/?appids=107410&format=json&l=german
```