### PR TITLE
Add Item test and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Each service from the Steam API has its own methods you can use.
 - [User Stats](#user-stats)
 - [App](#app)
 - [Package](#package)
+- [Item](#item)
 - [Group](#group)
 
 ### Global
@@ -349,6 +350,27 @@ l | string | The l is the language parameter, you can get the appropriate langua
 
 
 > Example Output: [packageDetails](./examples/package/packageDetails.txt)
+
+### Item
+This method will get user inventory for item.
+
+```php
+Steam::item()
+```
+
+#### GetPlayerItems
+This gets all the item for a user inventory.
+
+##### Arguments
+
+Name | Type | Description | Required | Default
+-----|------|-------------|----------|---------
+appId| int  | The appid of the game you want for | Yes |
+steamid | int | The steamid of the Steam user you want for | Yes |
+
+⚠️ **Now known to supports**:`440`, `570`, `620`, `730`, `205790`, `221540`, `238460`
+
+> Example Output: [GetPlayerItems](./examples/item/GetPlayerItems.txt)
 
 ### Group
 This service is used to get details on a Steam group.

--- a/examples/item/GetPlayerItems.txt
+++ b/examples/item/GetPlayerItems.txt
@@ -1,0 +1,303 @@
+Array
+(
+    [numberOfBackpackSlots] => 50
+    [items] => NukaCode\Database\Collection Object
+        (
+            [items:protected] => Array
+                (
+                    [0] => Syntax\SteamApi\Containers\Item Object
+                        (
+                            [id] => 5787837042
+                            [originalId] => 5787837042
+                            [defIndex] => 166
+                            [level] => 5
+                            [quality] => 6
+                            [quantity] => 1
+                            [inventory] => 0
+                            [origin] => 0
+                            [flags] => Array
+                                (
+                                    [trade] => 
+                                    [craft] => 1
+                                )
+
+                            [containedItem] => 
+                            [style] => 
+                            [attributes] => Array
+                                (
+                                    [0] => stdClass Object
+                                        (
+                                            [defindex] => 143
+                                            [value] => 1406566784
+                                            [float_value] => 1842591301632
+                                        )
+
+                                    [1] => stdClass Object
+                                        (
+                                            [defindex] => 746
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                    [2] => stdClass Object
+                                        (
+                                            [defindex] => 292
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                    [3] => stdClass Object
+                                        (
+                                            [defindex] => 388
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                    [4] => stdClass Object
+                                        (
+                                            [defindex] => 153
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                )
+
+                            [custom] => Array
+                                (
+                                    [name] => 
+                                    [description] => 
+                                )
+
+                        )
+
+                    [1] => Syntax\SteamApi\Containers\Item Object
+                        (
+                            [id] => 5787837069
+                            [originalId] => 5787837069
+                            [defIndex] => 877
+                            [level] => 1
+                            [quality] => 1
+                            [quantity] => 1
+                            [inventory] => 3221225480
+                            [origin] => 13
+                            [flags] => Array
+                                (
+                                    [trade] => 1
+                                    [craft] => 1
+                                )
+
+                            [containedItem] => 
+                            [style] => 
+                            [attributes] => Array
+                                (
+                                    [0] => stdClass Object
+                                        (
+                                            [defindex] => 746
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                    [1] => stdClass Object
+                                        (
+                                            [defindex] => 292
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                    [2] => stdClass Object
+                                        (
+                                            [defindex] => 388
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                )
+
+                            [custom] => Array
+                                (
+                                    [name] => 
+                                    [description] => 
+                                )
+
+                        )
+
+                    [2] => Syntax\SteamApi\Containers\Item Object
+                        (
+                            [id] => 5787837070
+                            [originalId] => 5787837070
+                            [defIndex] => 878
+                            [level] => 1
+                            [quality] => 1
+                            [quantity] => 1
+                            [inventory] => 3221225480
+                            [origin] => 13
+                            [flags] => Array
+                                (
+                                    [trade] => 1
+                                    [craft] => 1
+                                )
+
+                            [containedItem] => 
+                            [style] => 0
+                            [attributes] => Array
+                                (
+                                    [0] => stdClass Object
+                                        (
+                                            [defindex] => 746
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                    [1] => stdClass Object
+                                        (
+                                            [defindex] => 292
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                    [2] => stdClass Object
+                                        (
+                                            [defindex] => 388
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                )
+
+                            [custom] => Array
+                                (
+                                    [name] => 
+                                    [description] => 
+                                )
+
+                        )
+
+                    [3] => Syntax\SteamApi\Containers\Item Object
+                        (
+                            [id] => 5787837071
+                            [originalId] => 5787837071
+                            [defIndex] => 879
+                            [level] => 1
+                            [quality] => 1
+                            [quantity] => 1
+                            [inventory] => 3221225480
+                            [origin] => 13
+                            [flags] => Array
+                                (
+                                    [trade] => 1
+                                    [craft] => 1
+                                )
+
+                            [containedItem] => 
+                            [style] => 0
+                            [attributes] => Array
+                                (
+                                    [0] => stdClass Object
+                                        (
+                                            [defindex] => 746
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                    [1] => stdClass Object
+                                        (
+                                            [defindex] => 292
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                    [2] => stdClass Object
+                                        (
+                                            [defindex] => 388
+                                            [value] => 1115684864
+                                            [float_value] => 64
+                                        )
+
+                                )
+
+                            [custom] => Array
+                                (
+                                    [name] => 
+                                    [description] => 
+                                )
+
+                        )
+
+                    [4] => Syntax\SteamApi\Containers\Item Object
+                        (
+                            [id] => 5787837154
+                            [originalId] => 5787837154
+                            [defIndex] => 5867
+                            [level] => 1
+                            [quality] => 6
+                            [quantity] => 1
+                            [inventory] => 3221225473
+                            [origin] => 0
+                            [flags] => Array
+                                (
+                                    [trade] => 1
+                                    [craft] => 1
+                                )
+
+                            [containedItem] => 
+                            [style] => 0
+                            [attributes] => Array
+                                (
+                                    [0] => stdClass Object
+                                        (
+                                            [defindex] => 2046
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                    [1] => stdClass Object
+                                        (
+                                            [defindex] => 187
+                                            [value] => 1121189888
+                                            [float_value] => 106
+                                        )
+
+                                    [2] => stdClass Object
+                                        (
+                                            [defindex] => 744
+                                            [value] => 1
+                                            [float_value] => 1.4012984643248E-45
+                                        )
+
+                                    [3] => stdClass Object
+                                        (
+                                            [defindex] => 528
+                                            [value] => 1169641472
+                                            [float_value] => 5866
+                                        )
+
+                                    [4] => stdClass Object
+                                        (
+                                            [defindex] => 731
+                                            [value] => 1065353216
+                                            [float_value] => 1
+                                        )
+
+                                    [5] => stdClass Object
+                                        (
+                                            [defindex] => 815
+                                            [value] => 1
+                                            [float_value] => 1.4012984643248E-45
+                                        )
+
+                                )
+
+                            [custom] => Array
+                                (
+                                    [name] => 
+                                    [description] => 
+                                )
+
+                        )
+
+                )
+
+        )
+
+)
+

--- a/src/Syntax/SteamApi/Steam/Item.php
+++ b/src/Syntax/SteamApi/Steam/Item.php
@@ -40,7 +40,7 @@ class Item extends Client
         $items = $this->convertToObjects($client->result->items);
 
         // Return a full inventory
-        return new Inventory($client->result->num_backpack_slots, $items);
+        return (array) new Inventory($client->result->num_backpack_slots, $items);
     }
 
     protected function convertToObjects($items)

--- a/tests/BaseTester.php
+++ b/tests/BaseTester.php
@@ -17,6 +17,8 @@ class BaseTester extends TestCase {
 
     protected $packageId = 76710;
 
+    protected $itemid = 440;
+
     protected $groupId   = 103582791429521412;
 
     protected $groupName = 'Valve';
@@ -151,6 +153,15 @@ class BaseTester extends TestCase {
 
         $attributes = ['windows', 'mac', 'linux'];
         $this->assertObjectHasAttributes($attributes, $packahe->platforms);
+    }
+
+    /**
+     * @param $item
+     */
+    private function checkItemProperties($item)
+    {
+        $attributes = ['id', 'originalId', 'level', 'quality', 'quantity'];
+        $this->assertObjectHasAttributes($attributes, $item->item);
     }
 
     /**

--- a/tests/ItemTest.php
+++ b/tests/ItemTest.php
@@ -1,0 +1,19 @@
+<?php
+
+require_once 'BaseTester.php';
+
+/** @group Item */
+class ItemTest extends BaseTester
+{
+    /** @test */
+    public function it_gets_items_for_an_by_user_id()
+    {
+        $items = $this->steamClient->item()->GetPlayerItems($this->itemid, $this->id64);
+
+        $this->assertCount(1, $items);
+
+        $item = $items->first();
+
+        $this->checkItemProperties($item);
+    }
+}


### PR DESCRIPTION
This PR adds test and documentation for `Item`.

and I get `The Response content must be a string or object implementing __toString(), "object" given.` when I was testing, so I made a change:

```diff
-        return new Inventory($client->result->num_backpack_slots, $items);
+        return (array) new Inventory($client->result->num_backpack_slots, $items);
```

then it's worked, maybe there is a better way, but I didn't think of it 😔