### PR TITLE
Support Laravel's Automatic Package Discovery

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,5 +24,12 @@
       "Syntax\\SteamApi\\": "src/Syntax/SteamApi"
     }
   },
+   "extra": {
+       "laravel": {
+           "providers": [
+               "Syntax\\SteamApi\\SteamApiServiceProvider"
+           ]
+       }
+   },
   "minimum-stability": "stable"
 }


### PR DESCRIPTION
This allows Laravel to automatically discover this package, negating the need to manually edit `config/app.php`