### PR TITLE
Fix error if Steam returns empty response

### DIFF
--- a/src/Syntax/SteamApi/Steam/Player.php
+++ b/src/Syntax/SteamApi/Steam/Player.php
@@ -111,7 +111,7 @@ class Player extends Client
         // Get the client
         $client = $this->getServiceResponse($arguments);
 
-        if ($client->total_count > 0) {
+        if (isset($client->total_count) && $client->total_count > 0) {
             // Clean up the games
             $games = $this->convertToObjects($client->games);
 


### PR DESCRIPTION
Querying the API for a Steam user who has their gameplay history private returns:
```
"response": {}
```

which results in the error:
```
Undefined property: stdClass::$total_count in Player.php on line 120
```

To reproduce:
```php
$player = Steam::player(76561198160024140)->GetRecentlyPlayedGames();
```