### PR TITLE
Fix appdetails not follow l attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -320,8 +320,8 @@ This gets all the details for a game.  This is most of the information from the 
 Name | Type | Description | Required | Default
 -----|------|-------------|----------|---------
 appIds| int[] | The ids of the games you want details for | Yes |
-cc | string | The cc is the country code, you can get appropriate currency values according to [ISO 3166-1](https://wikipedia.org/wiki/ISO_3166-1) | No |
-l | string | The l is the language parameter, you can get the appropriate language according to [ISO 639-1](https://wikipedia.org/wiki/ISO_639-1) (If there is one) | No |
+cc | string | The cc is the country code, you can get appropriate currency values according to [ISO 3166-1](https://wikipedia.org/wiki/ISO_3166-1_alpha-2#Officially_assigned_code_elements) | No |
+l | string | The l is the language parameter, you can get the appropriate language according to [ISO 639-1](https://wikipedia.org/wiki/List_of_ISO_639-1_codes) | No |
 
 
 > Example Output: [appDetails](./examples/app/appDetails.txt)
@@ -387,4 +387,4 @@ group| string or int  | The ID or the name of the group. | Yes
 - [MaartenStaa](https://github.com/MaartenStaa)
 - [JRizzle88](https://github.com/JRizzle88)
 - [jastend](https://github.com/jastend)
-- [2er7](https://github.com/2er7)
+- [Teakowa](https://github.com/Teakowa)

--- a/src/Syntax/SteamApi/Client.php
+++ b/src/Syntax/SteamApi/Client.php
@@ -117,8 +117,15 @@ class Client
         // Build the query string
         $parameters = http_build_query($parameters);
 
+        $headers = [];
+        if (array_key_exists('l', $arguments)) {
+            $headers = [
+                'Accept-Language' => $arguments['l'],
+            ];
+        }
+
         // Send the request and get the results
-        $request  = new Request('GET', $steamUrl . '?' . $parameters);
+        $request  = new Request('GET', $steamUrl . '?' . $parameters, $headers);
         $response = $this->sendRequest($request);
 
         // Pass the results back


### PR DESCRIPTION
More info #77 

I think the `l` attribute should be keep, then judge the `l` attribute in `setUpClient` and add the `Accept-Language` HTTP header.

This also fixes the invalid `l` attribute in `packageDetails`.