### PR TITLE
Fix undefined property when supported languages field is not set

### DIFF
--- a/src/Syntax/SteamApi/Containers/App.php
+++ b/src/Syntax/SteamApi/Containers/App.php
@@ -83,7 +83,7 @@ class App extends BaseContainer
         $this->requiredAge        = (int)$app->required_age;
         $this->isFree             = $app->is_free;
         $this->shortDescription   = $app->short_description;
-        $this->supportedLanguages = $app->supported_languages;
+        $this->supportedLanguages = $this->checkIssetField($app, 'supported_languages', 'None');
         $this->recommendations    = $this->checkIssetField($app, 'recommendations', $this->getFakeRecommendationsObject());
         $this->achievements       = $this->checkIssetField($app, 'achievements', $this->getFakeAchievementsObject());
         $this->dlc                = $this->checkIssetCollection($app, 'dlc', new Collection());

--- a/src/Syntax/SteamApi/Containers/App.php
+++ b/src/Syntax/SteamApi/Containers/App.php
@@ -57,6 +57,8 @@ class App extends BaseContainer
     public $achievements;
 
     public $dlc;
+    
+    public $movies;
 
     public function __construct($app)
     {
@@ -87,6 +89,7 @@ class App extends BaseContainer
         $this->recommendations    = $this->checkIssetField($app, 'recommendations', $this->getFakeRecommendationsObject());
         $this->achievements       = $this->checkIssetField($app, 'achievements', $this->getFakeAchievementsObject());
         $this->dlc                = $this->checkIssetCollection($app, 'dlc', new Collection());
+        $this->movies             = $this->checkIssetCollection($app, 'movies', new Collection());
 
     }
 


### PR DESCRIPTION
Some apps do not have supported languages field set, causing a undefined property error. 

Example:

Counter-Strike Beta
https://store.steampowered.com/api/appdetails?appids=150