### PR TITLE
Fix an issue with the service provider and updat lock file

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "32ab0790bb1f0fe9cb584fbc5e4cd760",
+    "content-hash": "38f6e2b8348389c77825aed34832e0b1",
     "packages": [
         {
             "name": "brick/math",
@@ -281,16 +281,16 @@
         },
         {
             "name": "egulias/email-validator",
-            "version": "2.1.20",
+            "version": "2.1.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/egulias/EmailValidator.git",
-                "reference": "f46887bc48db66c7f38f668eb7d6ae54583617ff"
+                "reference": "563d0cdde5d862235ffe24a158497f4d490191b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/f46887bc48db66c7f38f668eb7d6ae54583617ff",
-                "reference": "f46887bc48db66c7f38f668eb7d6ae54583617ff",
+                "url": "https://api.github.com/repos/egulias/EmailValidator/zipball/563d0cdde5d862235ffe24a158497f4d490191b5",
+                "reference": "563d0cdde5d862235ffe24a158497f4d490191b5",
                 "shasum": ""
             },
             "require": {
@@ -335,7 +335,7 @@
                 "validation",
                 "validator"
             ],
-            "time": "2020-09-06T13:44:32+00:00"
+            "time": "2020-09-19T14:37:56+00:00"
         },
         {
             "name": "graham-campbell/result-type",

--- a/src/Syntax/SteamApi/SteamApiServiceProvider.php
+++ b/src/Syntax/SteamApi/SteamApiServiceProvider.php
@@ -33,7 +33,7 @@ class SteamApiServiceProvider extends ServiceProvider
     {
         $this->registerAlias();
 
-        $this->container->singleton('steam-api', function () {
+        $this->app->singleton('steam-api', function () {
             return new Client;
         });
     }
@@ -45,7 +45,7 @@ class SteamApiServiceProvider extends ServiceProvider
      */
     protected function registerAlias()
     {
-        $this->container->booting(function () {
+        $this->app->booting(function () {
             $loader = AliasLoader::getInstance();
             $loader->alias('Steam', 'Syntax\SteamApi\Facades\SteamApi');
         });


### PR DESCRIPTION
I had previosuly misread the Laravel upgraded documentation and therefore the service provider needs to continue using `$ths->app` instead of `$this->container` 🤦‍♂️. I have also gone ahead and updated the `composer.lock` file as there was a discrepancy between the lock and json file.