### PR TITLE
GetPlayerLevelDetails-error-handeling

### DIFF
--- a/src/Syntax/SteamApi/Steam/Player.php
+++ b/src/Syntax/SteamApi/Steam/Player.php
@@ -34,6 +34,10 @@ class Player extends Client
     public function GetPlayerLevelDetails()
     {
         $details = $this->GetBadges();
+        
+        if(count((array)$details) == 0){
+            return NULL;
+        }
 
         $details = new Level($details);
 


### PR DESCRIPTION
When a player's account is private and you call GetPlayerLevelDetails() the Containers\Player\Level class cannot be created because $details = $this->GetBadges(); will return empty and the Containers\Player\Level class constructor will fail.

Maybe return NULL so you can just check if GetPlayerLevelDetails() returns NULL there account is probably private.