### PR TITLE
Sometimes Steam returns an empty array. This fix avoids the throwable…

### DIFF
--- a/src/Syntax/SteamApi/Steam/Player.php
+++ b/src/Syntax/SteamApi/Steam/Player.php
@@ -28,7 +28,7 @@ class Player extends Client
         // Get the client
         $client = $this->getServiceResponse($arguments);
 
-        return $client->player_level;
+        return isset($client->player_level) ? $client->player_level : null;
     }
 
     public function GetPlayerLevelDetails()


### PR DESCRIPTION
Sometimes Steam returns an empty array. This fix avoids the throwable…