### PR TITLE
Throw an exception on empty response

### DIFF
--- a/src/Syntax/SteamApi/Client.php
+++ b/src/Syntax/SteamApi/Client.php
@@ -199,6 +199,11 @@ class Client
         } catch (Exception $e) {
             throw new ApiCallFailedException($e->getMessage(), $e->getCode(), $e);
         }
+        
+        // For some resources, the Steam API responds with an empty response
+        if (empty($result->body)) {
+            throw new ApiCallFailedException('API call failed due to empty response', $result->code);
+        }
 
         // If all worked out, return the result
         return $result;


### PR DESCRIPTION
Throws an exception when the Steam API responds with an empty response, which would normally cause the error `Invalid argument supplied for foreach() at vendor/syntax/steam-api/src/Syntax/SteamApi/Steam/App.php:79` 

For example:
Steam::app()->appDetails(1444140) 

See #124 for more info. Thanks